### PR TITLE
Argument parsing decorator & example

### DIFF
--- a/slackbot.py
+++ b/slackbot.py
@@ -1,4 +1,6 @@
-import slack,time
+import slack,time,argparse,io
+
+from contextlib import redirect_stdout,redirect_stderr
 
 class SlackBot:
 
@@ -45,6 +47,46 @@ class SlackBot:
                 return func(message)
         return wrap
     
+    def command_args(self, description, **kwargs):
+        """
+            Function decorator to easily accept positional and keyword arguments
+            in commands.
+        
+            description:    Brief summary of command's purpose.
+            name:           The name argparser will use when showing help messages.
+            **kwargs:
+                Keys:       Name for an argument to be added
+                Values:     Dict with args for add_argument (https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_argument)
+                            (value['prefix'] to add '-' or '--' for optional args)
+
+        """
+        def makeWrapper(func):
+
+            prog = kwargs.pop('name') if 'name' in kwargs else func.__name__
+            parser = argparse.ArgumentParser(description=description, conflict_handler='resolve', prog=prog)
+            for k,v in kwargs.items(): # Add every kwarg as an argument with provided settings
+                parser.add_argument((v.pop('prefix') if 'prefix' in v else '') + k, **v)
+
+
+            def wrapper(message):
+                args = message['text'].split(" ")[1:]
+                with io.StringIO() as buf, redirect_stdout(buf), redirect_stderr(buf):
+                    try:
+                        args = vars(parser.parse_args(args))
+                        output = buf.getvalue()
+                        if len(output):
+                            bot.say_in_channel(f"```{output}```", message['channel'])
+                    except SystemExit:
+                        output = buf.getvalue()
+                        if len(output):
+                            self.post_message(f"```{output}```", message['channel'])
+                        return
+                return func(message, args)
+
+            return wrapper
+                
+        return makeWrapper 
+
     def handle_message(self, **payload):
         """
             Executes bot command if the command is known
@@ -64,10 +106,11 @@ class SlackBot:
 
         if(command[0] in self.commands):
             response = self.commands[command[0]](payload['data'])
-            
-        if response == None:
+        else:
             response = '<@' + user + '> ' + default_response
-
+    
+        if response == None: return
+        
         self.post_message(response, channel)
 
     def setup_bot_events(self):

--- a/slackbot.py
+++ b/slackbot.py
@@ -1,4 +1,4 @@
-import slack,time,argparse,io
+import slack,time,io
 
 from contextlib import redirect_stdout,redirect_stderr
 
@@ -47,27 +47,16 @@ class SlackBot:
                 return func(message)
         return wrap
     
-    def command_args(self, description, **kwargs):
+    def command_args(self, parser):
         """
-            Function decorator to easily accept positional and keyword arguments
-            in commands.
+            Function decorator to more easily parse arguments.
         
-            description:    Brief summary of command's purpose.
-            name:           The name argparser will use when showing help messages.
-            **kwargs:
-                Keys:       Name for an argument to be added
-                Values:     Dict with args for add_argument (https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_argument)
-                            (value['prefix'] to add '-' or '--' for optional args)
-
+            parser: Some argument parsing object (argparse.ArgumentParser)
+                    which has child function parse_args, returning a dict
+                    of named arguments.
         """
         def makeWrapper(func):
-
-            prog = kwargs.pop('name') if 'name' in kwargs else func.__name__
-            parser = argparse.ArgumentParser(description=description, conflict_handler='resolve', prog=prog)
-            for k,v in kwargs.items(): # Add every kwarg as an argument with provided settings
-                parser.add_argument((v.pop('prefix') if 'prefix' in v else '') + k, **v)
-
-
+ 
             def wrapper(message):
                 args = message['text'].split(" ")[1:]
                 with io.StringIO() as buf, redirect_stdout(buf), redirect_stderr(buf):

--- a/sycsbot.py
+++ b/sycsbot.py
@@ -1,4 +1,4 @@
-import json,sys
+import json
 from slackbot import SlackBot
 
 with open('oauthtoken.txt', 'r') as f:
@@ -27,9 +27,8 @@ def setup(message):
 @SYCSBot.require_admin
 def stop(message):
     response = '<@' + message['user'] + '> ' + 'Stopping SYCS bot...'
-    post_message(response, message['channel'])
-    sys.exit()
-    return ""
+    SYCSBot.post_message(response, message['channel'])
+    raise SystemExit("Bot killed by admin.")
 
 @SYCSBot.command('getchannel')
 def getchannel(message):
@@ -54,6 +53,14 @@ def ping(message):
 @SYCSBot.require_admin
 def admintest(message):
     return "Admin only function executed"
+
+@SYCSBot.command('argtest')
+@SYCSBot.command_args("Test positional and keyword arguments and echo them.", name="!argtest",
+        foo={'prefix':'--', 'help':"Foo, optional keyword argument", 'type':str},
+        N={'help':"Required positional argument", 'type':int, 'nargs':1}
+    )
+def argtest(message, args):
+    return "`"+str(args)+"`"
 
 if __name__ == "__main__":
     SYCSBot.run()

--- a/sycsbot.py
+++ b/sycsbot.py
@@ -1,4 +1,4 @@
-import json
+import json,argparse
 from slackbot import SlackBot
 
 with open('oauthtoken.txt', 'r') as f:
@@ -54,11 +54,23 @@ def ping(message):
 def admintest(message):
     return "Admin only function executed"
 
-@SYCSBot.command('argtest')
-@SYCSBot.command_args("Test positional and keyword arguments and echo them.", name="!argtest",
-        foo={'prefix':'--', 'help':"Foo, optional keyword argument", 'type':str},
-        N={'help':"Required positional argument", 'type':int, 'nargs':1}
+
+argtest_argparser = argparse.ArgumentParser(
+        prog="!argtest",
+        description="Test positional and keyword argument parsing and echo results.",
+        conflict_handler='resolve'
     )
+argtest_argparser.add_argument('--foo',
+        help="Foo, optional keyword argument",
+        type=str
+    )
+argtest_argparser.add_argument('N',
+        help="Required positional argument",
+        type=int,
+        nargs=1
+    )
+@SYCSBot.command('argtest')
+@SYCSBot.command_args(argtest_argparser)
 def argtest(message, args):
     return "`"+str(args)+"`"
 


### PR DESCRIPTION
A decorator can be used for ease of argument parsing in bot commands.

The decorator, command_args, accepts a list of arguments to be used in an argparse.ArgumentParser instance. Keywords argument keys are used as argument names, and values should be dict to unpack into add_argument parameters. For optional arguments requiring a prefix of '-' or '--', the dict can also contain a 'prefix' value.

Potential issues:
  Method of adding prefix to argument name is dirty.

Potential fixes:
  Create the argparser instance outside and pass it in to the decorator.